### PR TITLE
Replace WSClient with akka-http

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,27 +5,29 @@ description := "Scala client to consume JSON home documents"
 
 organization := "de.kaufhof"
 
-version := "2.2.0"
+version := "2.1.0"
 
 licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
 homepage := Some(url("https://github.com/Galeria-Kaufhof/jsonhomeclient"))
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.11.9"
 
 scalacOptions ++= Seq("-language:reflectiveCalls", "-feature", "-deprecation")
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "2.2.0" % "test",
-  "org.mockito" % "mockito-core" % "1.9.5" % "test",
-  "com.typesafe.play" %% "play-test" % "2.5.9" % "test",
-  "com.typesafe.play" %% "play-ws" % "2.5.9",
-  "com.damnhandy" % "handy-uri-templates" % "2.0.1"
+  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
+  "org.mockito" % "mockito-core" % "2.7.20" % "test",
+  "de.heikoseeberger" %% "akka-http-play-json" % "1.15.0",
+  "com.typesafe.akka" %% "akka-http" % "10.0.5",
+  "com.typesafe.play" %% "play-json" % "2.6.0-M6",
+  "ch.qos.logback" % "logback-core" % "1.2.2",
+  "ch.qos.logback" % "logback-classic" % "1.2.2",
+  "org.slf4j" % "slf4j-api" % "1.7.25",
+  "com.damnhandy" % "handy-uri-templates" % "2.1.6"
 )
 
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
-
-net.virtualvoid.sbt.graph.Plugin.graphSettings
 
 // Publish settings
 publishTo := {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,0 @@
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
-
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")

--- a/src/main/scala/de/kaufhof/jsonhomeclient/JsonHomeClient.scala
+++ b/src/main/scala/de/kaufhof/jsonhomeclient/JsonHomeClient.scala
@@ -1,54 +1,66 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
 package de.kaufhof.jsonhomeclient
 
-import play.api.libs.json.JsValue
-import play.api.libs.ws._
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.MediaType.WithFixedCharset
+import akka.http.scaladsl.model.MediaTypes.`application/json`
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.settings.{ClientConnectionSettings, ConnectionPoolSettings, ParserSettings}
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.ActorMaterializer
+import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport
+import play.api.libs.json._
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scala.language.postfixOps
 
+
 /**
- * The client to load a json-home document and extract relevant information.
- * A client is responsible for a specific json-home host.
- *
- * @param host the json home host to load the home document from
- * @param ws the WSClient to use for loading the home document.
- *           In a Play 2.3.x application it can be created via `WS.client`,
- *           in other apps it can be created via
- *           `new NingWSClient(new AsyncHttpClientConfig.Builder().build())` (remember
- *           to `close()` the client when the application is stopped).
- * @param defaultHeaders possibility to put headers from app-context
- * @author <a href="mailto:martin.grotzke@inoio.de">Martin Grotzke</a>
- */
+  * The client to load a json-home document and extract relevant information.
+  * A client is responsible for a specific json-home host.
+  *
+  * @param host           the json home host to load the home document from
+  * @param defaultHeaders possibility to put headers from app-context
+  * @param system A [[akka.actor.ActorSystem]] required by akka-http and for determining the [[scala.concurrent.ExecutionContextExecutor]]
+  * @param materializer A [[ActorMaterializer]] required by akka-http
+  */
 
 class JsonHomeClient(val host: JsonHomeHost,
-                     val ws: WSClient,
-                     val defaultHeaders: Map[String, String] = Map("Accept" -> "application/json-home")) {
+                     val defaultHeaders: Map[String, String] = Map("Accept" -> "application/json-home"))(implicit val system: ActorSystem, materializer: ActorMaterializer) extends PlayJsonSupport {
+
+  private implicit val executionContext = system.dispatcher
+  private val headers = defaultHeaders.collect { case (k, v) => RawHeader(k, v) }.to[Seq]
+
+  private def `application/json-home`: WithFixedCharset = MediaType.applicationWithFixedCharset("json-home", HttpCharsets.`UTF-8`, "json-home")
+  private val parserSettings = ParserSettings(system).withCustomMediaTypes(`application/json-home`)
+  private val clientConSettings = ClientConnectionSettings(system).withParserSettings(parserSettings)
+  private val clientSettings = ConnectionPoolSettings(system).withConnectionSettings(clientConSettings)
+
+  override def unmarshallerContentTypes = List(`application/json`, `application/json-home`)
 
   protected[jsonhomeclient] def jsonHome(): Future[JsValue] = {
-    configure(
-      ws.url(host.jsonHomeUri.toString)
-        .withHeaders(defaultHeaders.toSeq: _*)
-    ).get().map(_.json)
+    Http().singleRequest(request = HttpRequest(uri = host.jsonHomeUri.toString).withHeaders(headers), settings = clientSettings).flatMap(response =>
+      Unmarshal(response.entity).to[JsValue]
+    )
   }
-
-  protected def configure(requestHolder: WSRequest): WSRequest = requestHolder
 
 }
 

--- a/src/test/scala/de/kaufhof/jsonhomeclient/IntegrationSpec.scala
+++ b/src/test/scala/de/kaufhof/jsonhomeclient/IntegrationSpec.scala
@@ -1,6 +1,6 @@
 package de.kaufhof.jsonhomeclient
 
 import org.scalatest.{BeforeAndAfterAll, Matchers, FunSpec}
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 trait IntegrationSpec extends FunSpec with Matchers with BeforeAndAfterAll with MockitoSugar

--- a/src/test/scala/de/kaufhof/jsonhomeclient/JsonHomeServiceSpec.scala
+++ b/src/test/scala/de/kaufhof/jsonhomeclient/JsonHomeServiceSpec.scala
@@ -1,8 +1,7 @@
 package de.kaufhof.jsonhomeclient
 
-import org.scalatest.Matchers
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
-import org.mockito.Matchers._
 
 class JsonHomeServiceSpec extends UnitSpec {
 

--- a/src/test/scala/de/kaufhof/jsonhomeclient/UnitSpec.scala
+++ b/src/test/scala/de/kaufhof/jsonhomeclient/UnitSpec.scala
@@ -1,6 +1,6 @@
 package de.kaufhof.jsonhomeclient
 
 import org.scalatest.{BeforeAndAfterAll, Matchers, FunSpec}
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 abstract class UnitSpec extends FunSpec with Matchers with BeforeAndAfterAll with MockitoSugar


### PR DESCRIPTION
This PR replaces play's WSClient with akka-http. This project was initially written for play 2.3 and we had to update it for play 2.4, for 2.5 and we would have to update it again for 2.6. And it would never work for different versions of play.  This change makes it unnecessary to pass in a WSClient any longer. Instead the caller has to provide an ActorSystem and Materializer (which come along with a started Play app anyway). This should make it way less dependend on changes in different versions of the play framework.